### PR TITLE
Migrate test to Pester 5

### DIFF
--- a/Tests/Get-ProGetUniversalPackage.Tests.ps1
+++ b/Tests/Get-ProGetUniversalPackage.Tests.ps1
@@ -42,13 +42,6 @@ BeforeAll {
         Publish-ProGetUniversalPackage -Session $session -FeedName $feedName -PackagePath $upackFile
     }
 
-    function Init
-    {
-        $script:result = $null
-        $script:upackFile = $null
-        GivenFeed $feedName
-    }
-
     function ThenError
     {
         param(
@@ -110,27 +103,23 @@ BeforeAll {
     }
 }
 
-Describe 'Get-ProGetUniversalPackage when package doesn''t exist' {
+Describe 'Get-ProGetUniversalPackage' {
     BeforeEach {
-        Init
+        $script:result = $null
+        $script:upackFile = $null
+        GivenFeed $feedName
     }
 
-    It 'should return nothing and provide an error' {
+    It 'should return nothing and provide an error when package doesn''t exist' {
         WhenGettingPackage 'Fubar' -ErrorAction SilentlyContinue
         ThenNothingReturned
         ThenError -Matches 'package\ was\ not\ found'
     }
 
-    It 'should return nothing and provide no error' {
+    It 'should return nothing and provide no error when package doesn''t exist' {
         WhenGettingPackage 'Fubar' -ErrorAction Ignore
         ThenNothingReturned
         ThenNoErrors
-    }
-}
-
-Describe 'Get-ProGetUniversalPackage' {
-    BeforeEach {
-        Init
     }
 
     It 'should return package' {
@@ -164,12 +153,6 @@ Describe 'Get-ProGetUniversalPackage' {
         WhenGettingPackage '*zz'
         ThenPackageReturned 'Fizz','Buzz'
         ThenNoErrors
-    }
-}
-
-Describe 'Get-ProGetUniversalPackage grab packages by group' {
-    BeforeEach {
-        Init
     }
 
     It 'should only return package within provided group when duplicate named packages are in other groups' {
@@ -208,7 +191,7 @@ Describe 'Get-ProGetUniversalPackage grab packages by group' {
     # When group is not passed in query string it grabs the first package with a matching name, no matter what group it is.
     # Should only grab the package with the name that is not in a group.
     # This is also failing a test in Remove-ProGetUniversalPackage.Tests ("should delete the package with no group").
-    It 'should return same named package that is not in group when group passed is an empty string' {
+    It 'should return same named package that is not in group when group passed an empty string' {
         GivenPackage 'Snafu'
         GivenPackage 'Snafu' -InGroup 'One'
         GivenPackage 'Snafu' -InGroup 'Two'

--- a/Tests/Get-ProGetUniversalPackage.Tests.ps1
+++ b/Tests/Get-ProGetUniversalPackage.Tests.ps1
@@ -204,6 +204,10 @@ Describe 'Get-ProGetUniversalPackage grab packages by group' {
         ThenNoErrors
     }
 
+    # Test is failing in Proget v2023. Not fixed in 2023.28 still.
+    # When group is not passed in query string it grabs the first package with a matching name, no matter what group it is.
+    # Should only grab the package with the name that is not in a group.
+    # This is also failing a test in Remove-ProGetUniversalPackage.Tests ("should delete the package with no group").
     It 'should return same named package that is not in group when group passed is an empty string' {
         GivenPackage 'Snafu'
         GivenPackage 'Snafu' -InGroup 'One'

--- a/Tests/Get-ProGetUniversalPackage.Tests.ps1
+++ b/Tests/Get-ProGetUniversalPackage.Tests.ps1
@@ -2,89 +2,84 @@
 #Requires -Version 5.1
 Set-StrictMode -Version 'Latest'
 
-& (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Tests.ps1' -Resolve)
+BeforeAll {
+    & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Tests.ps1' -Resolve)
 
-$session = New-ProGetTestSession
-$result = $null
-$upackFile = $null
-$feedName = 'Get-ProGetUniversalPackage.Tests.ps1'
+    $session = New-ProGetTestSession
+    $result = $null
+    $upackFile = $null
+    $feedName = 'Get-ProGetUniversalPackage.Tests.ps1'
 
-function GivenFeed
-{
-    param(
-        $Name
-    )
-
-    Get-ProGetFeed -Session $Session -Name $Name -ErrorAction Ignore | Remove-ProGetFeed -Session $Session -Force
-    New-ProGetFeed -Session $session -Name $Name -Type 'Universal'
-}
-
-function GivenPackage
-{
-    param(
-        [Parameter(Mandatory,Position=0)]
-        [string]
-        $Named,
-
-        [string]
-        $InGroup
-    )
-
-    $params = @{ }
-    if( $InGroup )
+    function GivenFeed
     {
-        $params['GroupName'] = $InGroup
+        param(
+            $Name
+        )
+
+        Get-ProGetFeed -Session $Session -Name $Name -ErrorAction Ignore | Remove-ProGetFeed -Session $Session -Force
+        New-ProGetFeed -Session $session -Name $Name -Type 'Universal'
     }
 
-    $script:upackFile = New-ProGetUniversalPackage -OutFile (Join-Path -Path $TestDrive.FullName -ChildPath ('{0}{1}.zip' -f $InGroup,$Named)) -Version '0.0.0' -Name $Named @params
-    Publish-ProGetUniversalPackage -Session $session -FeedName $feedName -PackagePath $upackFile
-}
+    function GivenPackage
+    {
+        param(
+            [Parameter(Mandatory,Position=0)]
+            [string]
+            $Named,
 
-function Init
-{
-    $script:result = $null
-    $script:upackFile = $null
-    GivenFeed $feedName
-}
+            [string]
+            $InGroup
+        )
 
-function ThenError
-{
-    param(
-        $Matches
-    )
+        $params = @{ }
+        if( $InGroup )
+        {
+            $params['GroupName'] = $InGroup
+        }
 
-    It ('should write error') {
+        $filepath = Join-Path -Path $TestDrive -ChildPath ('package.{0}.upack' -f [IO.Path]::GetRandomFileName())
+        $upackFile = New-ProGetUniversalPackage -OutFile $filepath -Version '0.0.0' -Name $Named @params
+        Publish-ProGetUniversalPackage -Session $session -FeedName $feedName -PackagePath $upackFile
+    }
+
+    function Init
+    {
+        $script:result = $null
+        $script:upackFile = $null
+        GivenFeed $feedName
+    }
+
+    function ThenError
+    {
+        param(
+            $Matches
+        )
+
         $Global:Error | Should -Match $Matches
     }
-}
 
-function ThenNoErrors
-{
-    param(
-    )
+    function ThenNoErrors
+    {
+        param(
+        )
 
-    It ('should write no errors') {
         $Global:Error | Should -BeNullOrEmpty
     }
-}
 
-function ThenNothingReturned
-{
-    It ('should return nothing') {
+    function ThenNothingReturned
+    {
         $result | Should -BeNullOrEmpty
     }
-}
 
-function ThenPackageReturned
-{
-    param(
-        [string[]]
-        $Named,
+    function ThenPackageReturned
+    {
+        param(
+            [string[]]
+            $Named,
 
-        $InGroup = ''
-    )
-
-    It ('should return package') {
+            $InGroup = ''
+        )
+        $result = $script:result
         $result | Should -HaveCount $Named.Count
         foreach( $name in $Named )
         {
@@ -92,137 +87,130 @@ function ThenPackageReturned
             $result | Where-Object { $_.group -eq $InGroup } | Should -HaveCount $Named.Count
         }
     }
-}
 
-function WhenGettingPackage
-{
-    [CmdletBinding()]
-    param(
-        $Named,
-        $InGroup
-    )
-
-    $params = @{ }
-    if( $PSBoundParameters.ContainsKey('Named') )
+    function WhenGettingPackage
     {
-        $params['Name'] = $Named
+        [CmdletBinding()]
+        param(
+            $Named,
+            $InGroup
+        )
+
+        $params = @{ }
+        if( $PSBoundParameters.ContainsKey('Named') )
+        {
+            $params['Name'] = $Named
+        }
+        if( $PSBoundParameters.ContainsKey('InGroup') )
+        {
+            $params['GroupName'] = $InGroup
+        }
+        $Global:Error.Clear()
+        $script:result = Get-ProGetUniversalPackage -Session $session -FeedName $feedName @params
     }
-    if( $PSBoundParameters.ContainsKey('InGroup') )
-    {
-        $params['GroupName'] = $InGroup
-    }
-    $Global:Error.Clear()
-    $script:result = Get-ProGetUniversalPackage -Session $session -FeedName $feedName @params
 }
 
-Describe 'Get-ProGetUniversalPackage.when package doesn''t exist' {
-    Init
-    WhenGettingPackage 'Fubar' -ErrorAction SilentlyContinue
-    ThenNothingReturned
-    ThenError -Matches 'package\ was\ not\ found'
-}
-
-Describe 'Get-ProGetUniversalPackage.when package doesn''t exist and ignoring any errors' {
-    Init
-    WhenGettingPackage 'Fubar' -ErrorAction Ignore
-    ThenNothingReturned
-    ThenNoErrors
-}
-
-Describe 'Get-ProGetUniversalPackage.when getting a package' {
-    Init
-    GivenPackage 'Snafu'
-    WhenGettingPackage 'Snafu'
-    ThenPackageReturned 'Snafu'
-    ThenNoErrors
-}
-
-Describe 'Get-ProGetUniversalPackage.when getting all packages' {
-    Init
-    GivenPackage 'Snafu'
-    GivenPackage 'Fizz'
-    GivenPackage 'Buzz'
-    WhenGettingPackage
-    ThenPackageReturned 'Snafu','Fizz','Buzz'
-    ThenNoErrors
-}
-
-Describe 'Get-ProGetUniversalPackage.when getting with wildcard' {
-    Init
-    GivenPackage 'Snafu'
-    GivenPackage 'Fizz'
-    GivenPackage 'Buzz'
-    WhenGettingPackage '*zz'
-    ThenPackageReturned 'Fizz','Buzz'
-    ThenNoErrors
-}
-
-if( $false )
-{
-    # There's currently a bug in ProGet that doesn't allow this.
-    Describe 'Get-ProGetUniversalPackage.when getting all packages in a group' {
+Describe 'Get-ProGetUniversalPackage when package doesn''t exist' {
+    BeforeEach {
         Init
-        GivenPackage 'Snafu0'
-        GivenPackage 'Snafu1' -InGroup 'One'
-        GivenPackage 'Snafu21' -InGroup 'Two'
-        GivenPackage 'Snafu22' -InGroup 'Two'
-        GivenPackage 'Snafu23' -InGroup 'Two'
-        GivenPackage 'Snafu3' -InGroup 'Three'
-        WhenGettingPackage -InGroup 'Two'
-        ThenPackageReturned 'Snafu21','Snafu22','Snafu23' -InGroup 'Two'
+    }
+
+    It 'should return nothing and provide an error' {
+        WhenGettingPackage 'Fubar' -ErrorAction SilentlyContinue
+        ThenNothingReturned
+        ThenError -Matches 'package\ was\ not\ found'
+    }
+
+    It 'should return nothing and provide no error' {
+        WhenGettingPackage 'Fubar' -ErrorAction Ignore
+        ThenNothingReturned
         ThenNoErrors
     }
 }
 
-Describe 'Get-ProGetUniversalPackage.when getting package in a group and there are duplicate packages in other groups' {
-    Init
-    GivenPackage 'Snafu'
-    GivenPackage 'Snafu' -InGroup 'One'
-    GivenPackage 'Snafu' -InGroup 'Two'
-    GivenPackage 'Snafu' -InGroup 'Three'
-    WhenGettingPackage 'Snafu' -InGroup 'Three'
-    ThenPackageReturned 'Snafu' -InGroup 'Three'
-    ThenNoErrors
+Describe 'Get-ProGetUniversalPackage' {
+    BeforeEach {
+        Init
+    }
+
+    It 'should return package' {
+        GivenPackage 'Snafu'
+        WhenGettingPackage 'Snafu'
+        ThenPackageReturned 'Snafu'
+        ThenNoErrors
+    }
+
+    It 'should return all packages when name passed is empty string' {
+        GivenPackage 'Snafu1'
+        GivenPackage 'Snafu2'
+        WhenGettingPackage ''
+        ThenPackageReturned 'Snafu1','Snafu2'
+        ThenNoErrors
+    }
+
+    It 'should return all packages when no group or name provided' {
+        GivenPackage 'Snap'
+        GivenPackage 'Fizz'
+        GivenPackage 'Buzz'
+        WhenGettingPackage
+        ThenPackageReturned 'Snap','Fizz','Buzz'
+        ThenNoErrors
+    }
+
+    It 'should return packages using wildcard on passed name' {
+        GivenPackage 'Fizz'
+        GivenPackage 'Buzz'
+        GivenPackage 'Bizzes'
+        WhenGettingPackage '*zz'
+        ThenPackageReturned 'Fizz','Buzz'
+        ThenNoErrors
+    }
 }
 
-Describe 'Get-ProGetUniversalPackage.when getting getting packages by group using wildcards' {
-    Init
-    GivenPackage 'Snafu0'
-    GivenPackage 'Snafu1' -InGroup 'One'
-    GivenPackage 'Snafu2' -InGroup 'Two'
-    GivenPackage 'Snafu3' -InGroup 'Three'
-    WhenGettingPackage -InGroup 'O*'
-    ThenPackageReturned 'Snafu1' -InGroup 'One'
-    ThenNoErrors
-}
+Describe 'Get-ProGetUniversalPackage grab packages by group' {
+    BeforeEach {
+        Init
+    }
 
-Describe 'Get-ProGetUniversalPackage.when passing empty string to group' {
-    Init
-    GivenPackage 'Snafu'
-    GivenPackage 'Snafu' -InGroup 'One'
-    GivenPackage 'Snafu' -InGroup 'Two'
-    GivenPackage 'Snafu' -InGroup 'Three'
-    WhenGettingPackage 'Snafu' -InGroup ''
-    ThenPackageReturned 'Snafu'
-    ThenNoErrors
-}
+    It 'should only return package within provided group when duplicate named packages are in other groups' {
+        GivenPackage 'Snafu'
+        GivenPackage 'Snafu' -InGroup 'One'
+        GivenPackage 'Snafu' -InGroup 'Two'
+        GivenPackage 'Snafu' -InGroup 'Three'
+        WhenGettingPackage 'Snafu' -InGroup 'Three'
+        ThenPackageReturned 'Snafu' -InGroup 'Three'
+        ThenNoErrors
+    }
 
-Describe 'Get-ProGetUniversalPackage.when passing empty string to name' {
-    Init
-    GivenPackage 'Snafu1'
-    GivenPackage 'Snafu2'
-    WhenGettingPackage ''
-    ThenPackageReturned 'Snafu1','Snafu2'
-    ThenNoErrors
-}
+    It 'should return all packages within a group' {
+        GivenPackage 'Snafu'
+        GivenPackage 'Snafu' -InGroup 'One'
+        GivenPackage 'Snafu' -InGroup 'Two'
+        GivenPackage 'Snafu22' -InGroup 'Two'
+        GivenPackage 'Snafu23' -InGroup 'Two'
+        GivenPackage 'Snafu' -InGroup 'Three'
+        WhenGettingPackage -InGroup 'Two'
+        ThenPackageReturned 'Snafu','Snafu22','Snafu23' -InGroup 'Two'
+        ThenNoErrors
+    }
 
-Describe 'Get-ProGetUniversalPackage.when searching for packages with the same name across groups with group wildcard' {
-    Init
-    GivenPackage 'Snafu'
-    GivenPackage 'Snafu' -InGroup 'One'
-    GivenPackage 'Snafu' -InGroup 'Two'
-    GivenPackage 'Snafu' -InGroup 'Three'
-    WhenGettingPackage 'Snafu' -InGroup 'O*'
-    ThenPackageReturned 'Snafu' -InGroup 'One'
-    ThenNoErrors
+    It 'should return all packages within a group using a wildcard on the group name' {
+        GivenPackage 'Snafu'
+        GivenPackage 'Snafu' -InGroup 'One'
+        GivenPackage 'Snafu' -InGroup 'Two'
+        GivenPackage 'Snafu' -InGroup 'Three'
+        WhenGettingPackage -InGroup 'O*'
+        ThenPackageReturned 'Snafu' -InGroup 'One'
+        ThenNoErrors
+    }
+
+    It 'should return same named package that is not in group when group passed is an empty string' {
+        GivenPackage 'Snafu'
+        GivenPackage 'Snafu' -InGroup 'One'
+        GivenPackage 'Snafu' -InGroup 'Two'
+        GivenPackage 'Snafu' -InGroup 'Three'
+        WhenGettingPackage 'Snafu' -InGroup ''
+        ThenPackageReturned 'Snafu'
+        ThenNoErrors
+    }
 }

--- a/Tests/Remove-ProGetUniversalPackage.Tests.ps1
+++ b/Tests/Remove-ProGetUniversalPackage.Tests.ps1
@@ -21,12 +21,6 @@ BeforeAll {
         Publish-ProGetUniversalPackage -Session $session -FeedName $feedName -PackagePath $packagePath
     }
 
-    function Init
-    {
-        Get-ProGetFeed -Session $session -Name $feedName -ErrorAction Ignore | Remove-ProGetFeed -Session $session -Force
-        New-ProGetFeed -Session $session -Name $feedName -Type 'Universal'
-    }
-
     function ThenError
     {
         param(
@@ -101,7 +95,8 @@ BeforeAll {
 
 Describe 'Remove-ProGetUniversalPackage' {
     BeforeEach {
-        Init
+        Get-ProGetFeed -Session $session -Name $feedName -ErrorAction Ignore | Remove-ProGetFeed -Session $session -Force
+        New-ProGetFeed -Session $session -Name $feedName -Type 'Universal'
     }
 
     It 'should delete the package' {
@@ -135,23 +130,19 @@ Describe 'Remove-ProGetUniversalPackage' {
         WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0' -WhatIf
         ThenPackageNotDeleted 'Fubar'
     }
-}
-
-Describe 'Remove-ProGetUniversalPackage with shared names' {
-    BeforeEach {
-        Init
-        GivenPackage 'Fubar' '0.0.0'
-        GivenPackage 'Fubar' '0.0.0' -InGroup 'group'
-    }
 
     # Test is failing in Proget v2023.
     # See Get-ProGetUniversalPackage.Tests for details on Proget issue.
-    It 'should delete the package with no group'{
+    It 'should delete the same named package that is not in a group'{
+        GivenPackage 'Fubar' '0.0.0'
+        GivenPackage 'Fubar' '0.0.0' -InGroup 'group'
         WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0'
         ThenPackageDeleted 'Fubar'
     }
 
-    It 'should not delete the package with a group'{
+    It 'should not delete the same named package that is in a group'{
+        GivenPackage 'Fubar' '0.0.0'
+        GivenPackage 'Fubar' '0.0.0' -InGroup 'group'
         WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0'
         ThenPackageNotDeleted 'Fubar' -InGroup 'group'
     }

--- a/Tests/Remove-ProGetUniversalPackage.Tests.ps1
+++ b/Tests/Remove-ProGetUniversalPackage.Tests.ps1
@@ -2,58 +2,53 @@
 #Requires -Version 5.1
 Set-StrictMode -Version 'Latest'
 
-& (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Tests.ps1' -Resolve)
+BeforeAll {
+    & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Tests.ps1' -Resolve)
+    
+    $feedName = $PSCommandPath | Split-Path -Leaf
+    $session = New-ProGetTestSession
 
-$feedName = $PSCommandPath | Split-Path -Leaf
-$session = New-ProGetTestSession
+    function GivenPackage
+    {
+        param(
+            $Name,
+            $Version,
+            $InGroup
+        )
 
-function GivenPackage
-{
-    param(
-        $Name,
-        $Version,
-        $InGroup
-    )
-
-    $packagePath = Join-Path -Path $TestDrive.FullName -ChildPath ('package.{0}.upack' -f [IO.Path]::GetRandomFileName())
-    New-ProGetUniversalPackage -OutFile $packagePath -Version $Version -Name $Name -GroupName $InGroup
-    Publish-ProGetUniversalPackage -Session $session -FeedName $feedName -PackagePath $packagePath
-}
-
-function Init
-{
-    Get-ProGetFeed -Session $session -Name $feedName -ErrorAction Ignore | Remove-ProGetFeed -Session $session -Force
-    New-ProGetFeed -Session $session -Name $feedName -Type 'Universal'
-}
-
-function ThenError
-{
-    param(
-        $Matches
-    )
-
-    It ('should write an error') {
-        $Global:Error | Should -Match $Matches
-
+        $packagePath = Join-Path -Path $TestDrive -ChildPath ('package.{0}.upack' -f [IO.Path]::GetRandomFileName())
+        New-ProGetUniversalPackage -OutFile $packagePath -Version $Version -Name $Name -GroupName $InGroup
+        Publish-ProGetUniversalPackage -Session $session -FeedName $feedName -PackagePath $packagePath
     }
-}
 
-function ThenNoError
-{
-    It ('should not write any errors') {
+    function Init
+    {
+        Get-ProGetFeed -Session $session -Name $feedName -ErrorAction Ignore | Remove-ProGetFeed -Session $session -Force
+        New-ProGetFeed -Session $session -Name $feedName -Type 'Universal'
+    }
+
+    function ThenError
+    {
+        param(
+            $Matches
+        )
+
+        $Global:Error | Should -Match $Matches
+    }
+
+    function ThenNoError
+    {
         $Global:Error | Should -BeNullOrEmpty
     }
-}
 
-function ThenPackageDeleted
-{
-    param(
-        $Named,
-        $InGroup,
-        $AtVersion
-    )
+    function ThenPackageDeleted
+    {
+        param(
+            $Named,
+            $InGroup,
+            $AtVersion
+        )
 
-    It ('should delete the package') {
         $package = Get-ProGetUniversalPackage -Session $session -FeedName $feedName -Name $Named -GroupName $InGroup -ErrorAction Ignore
         if( $AtVersion )
         {
@@ -61,19 +56,17 @@ function ThenPackageDeleted
         }
         $package | Should -BeNullOrEmpty
     }
-}
 
-function ThenPackageNotDeleted
-{
-    param(
-        $Named,
+    function ThenPackageNotDeleted
+    {
+        param(
+            $Named,
 
-        $InGroup,
+            $InGroup,
 
-        $AtVersion
-    )
+            $AtVersion
+        )
 
-    It ('should not delete the package') {
         $package = Get-ProGetUniversalPackage -Session $session -FeedName $feedName -Name $Named -GroupName $InGroup
         if( $AtVersion )
         {
@@ -81,89 +74,83 @@ function ThenPackageNotDeleted
         }
         $package | Should -Not -BeNullOrEmpty
     }
-}
 
-function WhenDeletingPackage
-{
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory,ParameterSetName='ByNameAndVersion')]
-        [string]
-        $Named,
+    function WhenDeletingPackage
+    {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory,ParameterSetName='ByNameAndVersion')]
+            [string]
+            $Named,
 
-        [Parameter(Mandatory,ParameterSetName='ByNameAndVersion')]
-        [string]
-        $AtVersion,
+            [Parameter(Mandatory,ParameterSetName='ByNameAndVersion')]
+            [string]
+            $AtVersion,
 
-        [string]
-        $InGroup,
+            [string]
+            $InGroup,
 
-        [Switch]
-        $WhatIf
-    )
+            [Switch]
+            $WhatIf
+        )
 
-    $Global:Error.Clear()
-    Remove-ProGetUniversalPackage -Session $session -FeedName $feedName -Name $Named -Version $AtVersion -GroupName $InGroup -WhatIf:$WhatIf
+        $Global:Error.Clear()
+        Remove-ProGetUniversalPackage -Session $session -FeedName $feedName -Name $Named -Version $AtVersion -GroupName $InGroup -WhatIf:$WhatIf
+    }
 }
 
 Describe 'Remove-ProGetUniversalPackage' {
-    Init
-    GivenPackage 'Fubar' '0.0.0'
-    WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0'
-    ThenPackageDeleted 'Fubar'
+    BeforeEach {
+        Init
+    }
+
+    It 'should delete the package' {
+        GivenPackage 'Fubar' '0.0.0'
+        WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0'
+        ThenPackageDeleted 'Fubar'
+    }
+
+    It 'should only delete provided version when package has multiple versions' {
+        GivenPackage 'Fubar' '0.0.0'
+        GivenPackage 'Fubar' '0.0.1'
+        GivenPackage 'Fubar' '0.0.2'
+        WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.1'
+        ThenPackageDeleted 'Fubar' -AtVersion '0.0.1'
+        ThenPackageNotDeleted 'Fubar' -AtVersion '0.0.0'
+        ThenPackageNotDeleted 'Fubar' -AtVersion '0.0.2'
+    }
+
+    It 'should write an error when package doesn''t exist' {
+        WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0' -ErrorAction SilentlyContinue
+        ThenError -Matches 'package\ not\ found'
+    }
+
+    It 'should not write an error when package doesn''t exist and ignoring errors' {
+        WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0' -ErrorAction Ignore
+        ThenNoError
+    }
+
+    It 'should not delete package when using -WhatIf' {
+        GivenPackage 'Fubar' '0.0.0'
+        WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0' -WhatIf
+        ThenPackageNotDeleted 'Fubar'
+    }
 }
 
-Describe 'Remove-ProGetUniversalPackage.when package with the same name in a group' {
-    Init
-    GivenPackage 'Fubar' '0.0.0'
-    GivenPackage 'Fubar' '0.0.0' -InGroup 'group'
-    WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0'
-    ThenPackageDeleted 'Fubar'
-    ThenPackageNotDeleted 'Fubar' -InGroup 'group'
-}
+Describe 'Remove-ProGetUniversalPackage with shared names' {
+    BeforeEach {
+        Init
+        GivenPackage 'Fubar' '0.0.0'
+        GivenPackage 'Fubar' '0.0.0' -InGroup 'group'
+    }
 
-Describe 'Remove-ProGetUniversalPackage.when package is in a group and package with the same name not in a group' {
-    Init
-    GivenPackage 'Fubar' '0.0.0'
-    GivenPackage 'Fubar' '0.0.0' -InGroup 'group'
-    WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0' -InGroup 'group'
-    ThenPackageDeleted 'Fubar' -InGroup 'group'
-    ThenPackageNotDeleted 'Fubar'
-}
+    It 'should delete the package with no group'{
+        WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0'
+        ThenPackageDeleted 'Fubar'
+    }
 
-Describe 'Remove-ProGetUniversalPackage.when package doesn''t exist' {
-    Init
-    WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0' -ErrorAction SilentlyContinue
-    ThenError -Matches 'package\ not\ found'
+    It 'should not delete the package with a group'{
+        WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0'
+        ThenPackageNotDeleted 'Fubar' -InGroup 'group'
+    }
 }
-
-Describe 'Remove-ProGetUniversalPackage.when using WhatIf' {
-    Init
-    GivenPackage 'Fubar' '0.0.0'
-    WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0' -WhatIf
-    ThenPackageNotDeleted 'Fubar'
-}
-
-Describe 'Remove-ProGetUniversalPackage.when there are multiple versions' {
-    Init
-    GivenPackage 'Fubar' '0.0.0'
-    GivenPackage 'Fubar' '0.0.1'
-    GivenPackage 'Fubar' '0.0.2'
-    WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.1'
-    ThenPackageDeleted 'Fubar' -AtVersion '0.0.1'
-    ThenPackageNotDeleted 'Fubar' -AtVersion '0.0.0'
-    ThenPackageNotDeleted 'Fubar' -AtVersion '0.0.2'
-}
-
-Describe 'Remove-ProGetUniversalPackage.when package doesn''t exist' {
-    Init
-    WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0' -ErrorAction SilentlyContinue
-    ThenError -Matches 'package\ not\ found'
-}
-
-Describe 'Remove-ProGetUniversalPackage.when package doesn''t exist and ignoring errors' {
-    Init
-    WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0' -ErrorAction Ignore
-    ThenNoError
-}
-

--- a/Tests/Remove-ProGetUniversalPackage.Tests.ps1
+++ b/Tests/Remove-ProGetUniversalPackage.Tests.ps1
@@ -144,6 +144,8 @@ Describe 'Remove-ProGetUniversalPackage with shared names' {
         GivenPackage 'Fubar' '0.0.0' -InGroup 'group'
     }
 
+    # Test is failing in Proget v2023.
+    # See Get-ProGetUniversalPackage.Tests for details on Proget issue.
     It 'should delete the package with no group'{
         WhenDeletingPackage -Named 'Fubar' -AtVersion '0.0.0'
         ThenPackageDeleted 'Fubar'

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -73,7 +73,6 @@ Build:
             - "*\\New-ProGetSession.Tests.ps1"
             - "*\\Read-ProGetUniversalPackageFile.Tests.ps1"
             - "*\\Remove-ProGetAsset.Tests.ps1"
-            - "*\\Remove-ProGetUniversalPackage.Tests.ps1"
 
 - Pester4:
     Script:
@@ -85,7 +84,6 @@ Build:
     - Tests\New-ProGetSession.Tests.ps1
     - Tests\Read-ProGetUniversalPackageFile.Tests.ps1
     - Tests\Remove-ProGetAsset.Tests.ps1
-    - Tests\Remove-ProGetUniversalPackage.Tests.ps1
     Verbose: false
 
 - Delete:

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -67,7 +67,6 @@ Build:
             ExcludePath:
             - "*\\Add-ProGetUniversalPackageFile.Tests.ps1"
             - "*\\Get-ProGetAsset.Tests.ps1"
-            - "*\\Get-ProGetUniversalPackage.Tests.ps1"
             - "*\\Invoke-ProGetNativeApiMethod.Tests.ps1"
             - "*\\Invoke-ProGetRestMethod.Tests.ps1"
             - "*\\New-ProGetSession.Tests.ps1"
@@ -78,7 +77,6 @@ Build:
     Script:
     - Tests\Add-ProGetUniversalPackageFile.Tests.ps1
     - Tests\Get-ProGetAsset.Tests.ps1
-    - Tests\Get-ProGetUniversalPackage.Tests.ps1
     - Tests\Invoke-ProGetNativeApiMethod.Tests.ps1
     - Tests\Invoke-ProGetRestMethod.Tests.ps1
     - Tests\New-ProGetSession.Tests.ps1


### PR DESCRIPTION
- Migrating Get-ProGetUniversalPackage.Tests and Remove-ProGetUniversalPackage.Tests to Pester 5. 
- Provide hints to the 2 failing tests due to an issue with Proget 2023 that is preventing us from upgrading. As of 2023.28 the issue is not fixed.